### PR TITLE
Adding rest calls for clockout, breakin, and breakout

### DIFF
--- a/src/main/java/org/ClockDbHandler.java
+++ b/src/main/java/org/ClockDbHandler.java
@@ -19,22 +19,68 @@ public class ClockDbHandler {
         }catch(Exception e){        }
     }
     
-    public Clock_State getEmployeeClockState(int employee_id){
+    public Clock_State getEmployeeClockState(int employee_id, int shift_id){
     	OraclePreparedStatement stmt = null;
     	try {
             stmt = (OraclePreparedStatement) con.prepareStatement(
-            		"select state from employees where ID = ?");
+            		"select emp.state from employees emp "
+            		+ "join worked_shifts wrk on emp.ID = wrk.EMPLOYEE_ID "
+            		+ "where emp.ID = ? and wrk.scheduled_shift_id = ?");
             stmt.setInt(1, employee_id);
+            stmt.setInt(2, shift_id);
             ResultSet i = stmt.executeQuery();
-            if (i.next()){
+            if( !i.next() ){
+            	return Clock_State.NOT_CLOCKED_IN;
+            }else {
             	//parse result
             	int state = i.getInt(1);
+            	System.out.println("State: " + state);
             	switch(state){
-            	case 0: return Clock_State.NOT_CLOCKED_IN;
+            	//shift has been worked. Do not allow another clockin
+            	case 0: return Clock_State.SHIFT_COMPLETE;
             	case 1: return Clock_State.CLOCKED_IN;
             	case 2: return Clock_State.BREAK;
             	default: return null;
             	}
+            }
+        }catch(Exception e){
+        }finally{
+        	try{stmt.close();}catch(Exception ignore){}
+        }
+    	return null;
+    }
+    
+    public Employee getEmployeeClockStateandWorkedShiftID(int employee_id, int shift_id){
+    	OraclePreparedStatement stmt = null;
+    	try {
+            stmt = (OraclePreparedStatement) con.prepareStatement(
+            		"select emp.state, wrk.ID from employees emp "
+            		+ "join worked_shifts wrk on emp.ID = wrk.EMPLOYEE_ID "
+            		+ "where emp.ID = ? and wrk.scheduled_shift_id = ?");
+            stmt.setInt(1, employee_id);
+            stmt.setInt(2, shift_id);
+            ResultSet i = stmt.executeQuery();
+            
+            Employee emp = new Employee(employee_id, null);
+            
+            if( !i.next() ){
+            	emp.setEmployeeClockState(Clock_State.NOT_CLOCKED_IN);
+            }else {
+            	//parse result
+            	int state = i.getInt(1);
+            	System.out.println("State: " + state);
+            	switch(state){
+            	//shift has been worked. Do not allow another clockin
+            	case 0: emp.setEmployeeClockState(Clock_State.SHIFT_COMPLETE);
+            	break;
+            	case 1: emp.setEmployeeClockState(Clock_State.CLOCKED_IN);
+            	break;
+            	case 2: emp.setEmployeeClockState(Clock_State.BREAK);
+            	break;
+            	default: return null;
+            	}
+            	emp.setCurrent_worked_shift_id(i.getInt(2));
+            	return emp;
             }
         }catch(Exception e){
         }finally{
@@ -75,10 +121,11 @@ public class ClockDbHandler {
     public String clockInWithScheduledShift(int employee_id, int shift_id, int location_id){
     	OraclePreparedStatement stmt = null;
     	try {
-        	if(getEmployeeClockState(employee_id) != Clock_State.NOT_CLOCKED_IN){
-        		return "Duplicate clockin - duplicate employeeId "+employee_id+" and shiftId "+shift_id;
+    		Clock_State state = getEmployeeClockState(employee_id, shift_id);
+        	if(state != Clock_State.NOT_CLOCKED_IN){
+        		return "Error with employee state => clock_state "+state+", employeeId "+employee_id+", shiftId "+shift_id;
         	}
-        	System.out.println("Log: Clock_State.NOT_CLOCKED_IN");
+        	System.out.println("Log: Clock_State =" + state.name());
         	
             stmt = (OraclePreparedStatement) con.prepareStatement(
             		"INSERT INTO worked_shifts(start_time,scheduled_shift_ID,employee_ID, location_ID) VALUES (?,?,?,?)");
@@ -93,7 +140,107 @@ public class ClockDbHandler {
         	if( !updateEmployeeState(employee_id, Clock_State.CLOCKED_IN)){
         		return "Error updating employee state => employeeId "+employee_id+" and shiftId "+shift_id;
         	}
-        	System.out.println("Log: Clock_State.CLOCKED_IN");
+        	System.out.println("Log: Clock_State =" + state.name());
+            return ""; //success
+            	
+        }catch(Exception e){
+            return e.getMessage();
+        }finally{
+        	try{stmt.close();}catch(Exception ignore){}
+        }
+    }
+    
+    public String breakInWithScheduledShift(int employee_id, int shift_id, int location_id){
+    	OraclePreparedStatement stmt = null;
+    	try {
+    		Employee emp = getEmployeeClockStateandWorkedShiftID(employee_id, shift_id);
+    		Clock_State state = emp.getEmployeeClockState();
+        	if(state != Clock_State.CLOCKED_IN){
+        		return "Error with employee state => clock_state "+state+", employeeId "+employee_id+", shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+        	
+            stmt = (OraclePreparedStatement) con.prepareStatement(
+            		"INSERT INTO breaks(start_time, worked_shift_ID)"
+            		+ "VALUES (?,?)");
+            stmt.setTIMESTAMP(1, new TIMESTAMP(new Date(System.currentTimeMillis())));
+            stmt.setInt(2, emp.getCurrent_worked_shift_id());
+            int i = stmt.executeUpdate();
+            if (i <= 0){
+            	return "Update of breaks failed => employeeId "+employee_id+" and shiftId "+shift_id;
+            }
+        	if( !updateEmployeeState(employee_id, Clock_State.BREAK)){
+        		return "Error updating employee state => clock_state "+state+",employeeId "+employee_id+" and shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+            return ""; //success
+            	
+        }catch(Exception e){
+            return e.getMessage();
+        }finally{
+        	try{stmt.close();}catch(Exception ignore){}
+        }
+    }
+    
+    public String breakOutWithScheduledShift(int employee_id, int shift_id, int location_id){
+    	OraclePreparedStatement stmt = null;
+    	try {
+    		Employee emp = getEmployeeClockStateandWorkedShiftID(employee_id, shift_id);
+    		Clock_State state = emp.getEmployeeClockState();
+        	if(state != Clock_State.BREAK){
+        		return "Error with employee state => clock_state "+state+", employeeId "+employee_id+", shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+        	
+            stmt = (OraclePreparedStatement) con.prepareStatement(
+            		"update breaks set end_time = ? "
+            		+ "where worked_shift_id = ?");
+            stmt.setTIMESTAMP(1, new TIMESTAMP(new Date(System.currentTimeMillis())));
+            stmt.setInt(2, emp.getCurrent_worked_shift_id());
+            int i = stmt.executeUpdate();
+            if (i <= 0){
+            	return "Update of breaks failed => employeeId "+employee_id+" and shiftId "+shift_id;
+            }
+        	if( !updateEmployeeState(employee_id, Clock_State.CLOCKED_IN)){
+        		return "Error updating employee state => clock_state "+state+",employeeId "+employee_id+" and shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+            return ""; //success
+            	
+        }catch(Exception e){
+            return e.getMessage();
+        }finally{
+        	try{stmt.close();}catch(Exception ignore){}
+        }
+    }
+
+
+    public String clockOutWithScheduledShift(int employee_id, int shift_id, int location_id){
+    	OraclePreparedStatement stmt = null;
+    	try {
+    		Clock_State state = getEmployeeClockState(employee_id, shift_id);
+        	if(state != Clock_State.CLOCKED_IN){
+        		return "Error with employee state => clock_state "+state+", employeeId "+employee_id+", shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+        	
+            stmt = (OraclePreparedStatement) con.prepareStatement(
+            		"update worked_shifts set end_time = ? where "
+            		+ "scheduled_shift_id = ? and "
+            		+ "employee_id = ? and "
+            		+ "location_id = ?");
+            stmt.setTIMESTAMP(1, new TIMESTAMP(new Date(System.currentTimeMillis())));
+            stmt.setInt(2, shift_id);
+            stmt.setInt(3, employee_id);
+            stmt.setInt(4, location_id);
+            int i = stmt.executeUpdate();
+            if (i <= 0){
+            	return "Update of worked_shifts failed => employeeId "+employee_id+" and shiftId "+shift_id;
+            }
+        	if( !updateEmployeeState(employee_id, Clock_State.NOT_CLOCKED_IN)){
+        		return "Error updating employee state => clock_state "+state+",employeeId "+employee_id+" and shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
             return ""; //success
             	
         }catch(Exception e){

--- a/src/main/java/org/ClockDbHandler.java
+++ b/src/main/java/org/ClockDbHandler.java
@@ -249,4 +249,40 @@ public class ClockDbHandler {
         	try{stmt.close();}catch(Exception ignore){}
         }
     }
+    
+    public String addNoteWithScheduledShift(int employee_id, int shift_id, String worked_note){
+    	OraclePreparedStatement stmt = null;
+    	try {
+    		Employee emp = getEmployeeClockStateandWorkedShiftID(employee_id, shift_id);
+    		Clock_State state = emp.getEmployeeClockState();
+        	if(state != Clock_State.CLOCKED_IN){
+        		return "Error with employee state => clock_state "+state+", employeeId "+employee_id+", shiftId "+shift_id;
+        	}
+        	System.out.println("Log: Clock_State =" + state.name());
+        	
+        	//truncate if worked_note is longer than 256
+        	if(worked_note.length()>256){
+        		worked_note = worked_note.substring(0,255);
+        	}
+        	
+        	System.out.println("Log: worked_note: "+ worked_note);
+        	
+            stmt = (OraclePreparedStatement) con.prepareStatement(
+            		"update worked_shifts set worked_notes = ? "
+            		+ "where id = ?");
+            stmt.setString(1, worked_note);
+            stmt.setInt(2, emp.getCurrent_worked_shift_id());
+            int i = stmt.executeUpdate();
+            if (i <= 0){
+            	return "Update of breaks failed => employeeId "+employee_id+" and shiftId "+shift_id;
+            }
+        	System.out.println("Log: Clock_State =" + state.name());
+            return ""; //success
+            	
+        }catch(Exception e){
+            return e.getMessage();
+        }finally{
+        	try{stmt.close();}catch(Exception ignore){}
+        }
+    }
 }

--- a/src/main/java/org/ClockinParameters.java
+++ b/src/main/java/org/ClockinParameters.java
@@ -5,6 +5,7 @@ public class ClockinParameters {
 	private int employeeId;
 	private int shiftId;
 	private int locationId;
+	private String workedNote;
 	
 	public int getEmployeeId() {
 		return employeeId;
@@ -20,5 +21,11 @@ public class ClockinParameters {
 	}
 	public void setShiftId(int shiftId) {
 		this.shiftId = shiftId;
+	}
+	public String getWorkedNote() {
+		return workedNote;
+	}
+	public void setWorkedNote(String workedNote) {
+		this.workedNote = workedNote;
 	}
 }

--- a/src/main/java/org/Employee.java
+++ b/src/main/java/org/Employee.java
@@ -9,9 +9,10 @@ public class Employee {
     private int company_id;
     private boolean manager;
     private boolean super_admin;
+    private int current_worked_shift_id;
     private Clock_State emp_clock_state;
     public enum Clock_State {
-    	NOT_CLOCKED_IN, CLOCKED_IN, BREAK    	
+    	NOT_CLOCKED_IN, CLOCKED_IN, BREAK, SHIFT_COMPLETE    	
     };
     
     public Employee(int id, String name){
@@ -78,5 +79,13 @@ public class Employee {
 
 	public void setEmployeeClockState(Clock_State emp_clock_state) {
 		this.emp_clock_state = emp_clock_state;
+	}
+
+	public int getCurrent_worked_shift_id() {
+		return current_worked_shift_id;
+	}
+
+	public void setCurrent_worked_shift_id(int current_worked_shift_id) {
+		this.current_worked_shift_id = current_worked_shift_id;
 	}
 }

--- a/src/main/java/org/apache/wink/rest/ClockinResource.java
+++ b/src/main/java/org/apache/wink/rest/ClockinResource.java
@@ -47,6 +47,7 @@ public class ClockinResource {
 	private static final String PATH_CLOCKOUT 		= "clockout";
 	private static final String PATH_BREAKIN 		= "breakin";
 	private static final String PATH_BREAKOUT 		= "breakout";
+	private static final String PATH_ADDSHIFTNOTE 	= "addshiftnote";
 	private static final String PATH_JSON          	= "json";
 	private static final String PATH_AUTHENTICATE  	= "authenticate";
 	private static final String PATH_CONNECTIONS	= "database/connections";
@@ -134,6 +135,28 @@ public class ClockinResource {
     	
 		ClockDbHandler clk = new ClockDbHandler();
 		String error = clk.breakOutWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getLocationID());
+    	if( error.length() > 0 ){
+    		status = Response.Status.INTERNAL_SERVER_ERROR;
+    		result = "{\"Status\":\""+ error +"\"}";
+    	}
+    	
+		return Response.status(status).entity(result).build();
+    }
+    
+    @Path(PATH_ADDSHIFTNOTE)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addnote(String obj) {
+    	
+    	Status status = Response.Status.OK;
+    	
+    	ClockinParameters params = gson.fromJson(obj, ClockinParameters.class);
+
+    	String result = "{\"Status\":\"Employee "+ params.getEmployeeId() +" has added or modified their shift notes.\"}";
+    	
+		ClockDbHandler clk = new ClockDbHandler();
+		String error = clk.addNoteWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getWorkedNote());
     	if( error.length() > 0 ){
     		status = Response.Status.INTERNAL_SERVER_ERROR;
     		result = "{\"Status\":\""+ error +"\"}";

--- a/src/main/java/org/apache/wink/rest/ClockinResource.java
+++ b/src/main/java/org/apache/wink/rest/ClockinResource.java
@@ -44,6 +44,9 @@ import java.sql.*;
 public class ClockinResource {
 	
 	private static final String PATH_CLOCKIN 		= "clockin";
+	private static final String PATH_CLOCKOUT 		= "clockout";
+	private static final String PATH_BREAKIN 		= "breakin";
+	private static final String PATH_BREAKOUT 		= "breakout";
 	private static final String PATH_JSON          	= "json";
 	private static final String PATH_AUTHENTICATE  	= "authenticate";
 	private static final String PATH_CONNECTIONS	= "database/connections";
@@ -61,7 +64,7 @@ public class ClockinResource {
     	
     	ClockinParameters params = gson.fromJson(obj, ClockinParameters.class);
 
-    	String result = "{\"Status\":\""+ params.getEmployeeId() +"\"}";
+    	String result = "{\"Status\":\"Employee "+ params.getEmployeeId() +" is clocked in.\"}";
     	
 		ClockDbHandler clk = new ClockDbHandler();
 		String error = clk.clockInWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getLocationID());
@@ -73,7 +76,79 @@ public class ClockinResource {
 		return Response.status(status).entity(result).build();
     }
     
+    @Path(PATH_CLOCKOUT)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response clockout(String obj) {
     	
+    	Status status = Response.Status.OK;
+    	
+    	ClockinParameters params = gson.fromJson(obj, ClockinParameters.class);
+
+    	String result = "{\"Status\":\"Employee "+ params.getEmployeeId() +" is clocked out.\"}";
+    	
+		ClockDbHandler clk = new ClockDbHandler();
+		String error = clk.clockOutWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getLocationID());
+    	if( error.length() > 0 ){
+    		status = Response.Status.INTERNAL_SERVER_ERROR;
+    		result = "{\"Status\":\""+ error +"\"}";
+    	}
+    	
+		return Response.status(status).entity(result).build();
+    }
+    
+    @Path(PATH_BREAKIN)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response breakin(String obj) {
+    	
+    	Status status = Response.Status.OK;
+    	
+    	ClockinParameters params = gson.fromJson(obj, ClockinParameters.class);
+
+    	String result = "{\"Status\":\"Employee "+ params.getEmployeeId() +" is on break.\"}";
+    	
+		ClockDbHandler clk = new ClockDbHandler();
+		String error = clk.breakInWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getLocationID());
+    	if( error.length() > 0 ){
+    		status = Response.Status.INTERNAL_SERVER_ERROR;
+    		result = "{\"Status\":\""+ error +"\"}";
+    	}
+    	
+		return Response.status(status).entity(result).build();
+    }
+    
+    @Path(PATH_BREAKOUT)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response breakout(String obj) {
+    	
+    	Status status = Response.Status.OK;
+    	
+    	ClockinParameters params = gson.fromJson(obj, ClockinParameters.class);
+
+    	String result = "{\"Status\":\"Employee "+ params.getEmployeeId() +" is off break.\"}";
+    	
+		ClockDbHandler clk = new ClockDbHandler();
+		String error = clk.breakOutWithScheduledShift(params.getEmployeeId(), params.getShiftId(), params.getLocationID());
+    	if( error.length() > 0 ){
+    		status = Response.Status.INTERNAL_SERVER_ERROR;
+    		result = "{\"Status\":\""+ error +"\"}";
+    	}
+    	
+		return Response.status(status).entity(result).build();
+    }
+    
+    
+    /*
+     * Test REST calls
+     * 1. Json is the most basic call - to ensure the system is up and running
+     * 2. 
+     */
+       	
     @Path(PATH_JSON)
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/webapp/WEB-INF/bookmarks.properties
+++ b/src/main/webapp/WEB-INF/bookmarks.properties
@@ -17,4 +17,4 @@
 ## under the License.
 ##
 
-wink.defaultUrisRelative=false
+wink.defaultUrisRelative=true

--- a/src/main/webapp/WEB-INF/bookmarks.properties
+++ b/src/main/webapp/WEB-INF/bookmarks.properties
@@ -17,4 +17,4 @@
 ## under the License.
 ##
 
-wink.defaultUrisRelative=true
+wink.defaultUrisRelative=false


### PR DESCRIPTION
**clockout, breakin, breakout**
Test setup:
All are `POST`s.
JSON body:
{
	"employeeId": 1,
	"shiftId": 1,
	"locationId": 1
}
Headers:
Content-Type: application/json

Testing:
1. http://localhost:8080/Scheduler/rest/clockin/clockout
- Updates `worked_shifts` and sets employee's state to NOT_CLOCKED_IN
- Added a new query on `clockin` to check if the scheduled shift has already been clocked in for.
2. http://localhost:8080/Scheduler/rest/clockin/breakin
- Creates `break` and updates employee's state to `BREAK`
3. http://localhost:8080/Scheduler/rest/clockin/breakout
- Updates `break`  and sets employee's state to `CLOCKED_IN`